### PR TITLE
Avoid blocking the render loop by long computations

### DIFF
--- a/Physics/src/Drawables/DrawableTimeDependentFemMesh.cpp
+++ b/Physics/src/Drawables/DrawableTimeDependentFemMesh.cpp
@@ -1,15 +1,18 @@
 #include "DrawableTimeDependentFemMesh.hpp"
 
 DrawableTimeDependentFemMesh::DrawableTimeDependentFemMesh(const HeatEquationWithoutSource& fem)
-    : m_femProblem(fem), DrawableMesh(fem.GetGraph())
+    : DrawableMesh(fem.GetGraph()), m_femProblem(fem)
 {
+    m_femProblem.StartComputation();
 }
 
 void DrawableTimeDependentFemMesh::Update(float deltaTime)
 {
-    m_femProblem.SolveNextTimeStep();
-    std::cout << "Time: " << m_femProblem.CurrentTime() << "s" << std::endl;
-    UpdateValues();
+    if (m_femProblem.PollNextTimeStepReady())
+    {
+        std::cout << "Time: " << m_femProblem.CurrentTime() << "s" << std::endl;
+        UpdateValues();
+    }
 }
 
 // ReSharper disable once CppMemberFunctionMayBeConst

--- a/Physics/src/Fem/FemAssembler.cpp
+++ b/Physics/src/Fem/FemAssembler.cpp
@@ -1,4 +1,7 @@
 #include "FemAssembler.hpp"
+
+#include "LinearAlgebra/FactorizationLU.hpp"
+
 #include <unordered_set>
 
 namespace FemAssembler

--- a/Physics/src/Fem/HeatEquationWithoutSource.cpp
+++ b/Physics/src/Fem/HeatEquationWithoutSource.cpp
@@ -1,6 +1,16 @@
 #include "HeatEquationWithoutSource.hpp"
 #include "FemAssembler.hpp"
 #include <LinearAlgebra/FactorizationLU.hpp>
+#include <future>
+
+HeatEquationWithoutSource::HeatEquationWithoutSource(const HeatEquationWithoutSource& other)
+    : m_mesh(other.m_mesh), m_k(other.m_k), m_dt(other.m_dt),
+      m_time(other.m_time),
+      m_massMatrix(other.m_massMatrix),
+      m_stiffnessMatrix(other.m_stiffnessMatrix),
+      m_currentSolution(other.m_currentSolution)
+{
+}
 
 HeatEquationWithoutSource::HeatEquationWithoutSource(const Geometry::Mesh2D& mesh, const float k, const float dt, const FemAssembler::VertexValueFunc& initialValues)
     : m_mesh(mesh), m_k(k), m_dt(dt), m_time(0),
@@ -12,10 +22,41 @@ HeatEquationWithoutSource::HeatEquationWithoutSource(const Geometry::Mesh2D& mes
     FemAssembler::Add_Matrix_NablaA_NablaV(mesh, m_stiffnessMatrix, 1.0f * m_k);
 }
 
-void HeatEquationWithoutSource::SolveNextTimeStep()
+bool HeatEquationWithoutSource::PollNextTimeStepReady()
 {
-    m_currentSolution =
-        LinearAlgebra::Factorization::LUSolve(m_massMatrix + m_stiffnessMatrix * m_dt, 
-            m_massMatrix * m_currentSolution, 1e-6f);
-    m_time += m_dt;
+    if (!m_computeNextStepTask.valid())
+    {
+        m_computeNextStepTask = CreateNextTimeStepComputationTask();
+    }
+
+    if (m_computeNextStepTask.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+    {
+        m_currentSolution = m_computeNextStepTask.get();
+        m_time += m_dt;
+        m_computeNextStepTask = CreateNextTimeStepComputationTask();
+        return true;
+    }
+
+    return false;
+}
+void HeatEquationWithoutSource::StartComputation()
+{
+    PollNextTimeStepReady();
+}
+
+HeatEquationWithoutSource::~HeatEquationWithoutSource()
+{
+    if (m_computeNextStepTask.valid())
+    {
+        // Wait for any background computations before destruction
+        // TODO: implement better way to destruct. Avoid deadlocks..
+        m_computeNextStepTask.wait();
+    }
+}
+
+std::future<LinearAlgebra::ColumnVector<float>> HeatEquationWithoutSource::CreateNextTimeStepComputationTask() const
+{
+    return std::async([this]
+                      { return LinearAlgebra::Factorization::LUSolve(m_massMatrix + m_stiffnessMatrix * m_dt,
+                                                                     m_massMatrix * m_currentSolution, 1e-6f); });
 }

--- a/Physics/src/Fem/HeatEquationWithoutSource.hpp
+++ b/Physics/src/Fem/HeatEquationWithoutSource.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "FemAssembler.hpp"
 #include <Geometry/Structures/Mesh2D.hpp>
-#include <Geometry/Structures/Vertex.hpp>
 #include <LinearAlgebra/Matrix.hpp>
 #include <LinearAlgebra/VectorBase.hpp>
-#include <functional>
-#include "FemAssembler.hpp"
+
+#include <future>
 
 /// <summary>
 /// Helmholtz equation with source
@@ -15,16 +15,22 @@
 class HeatEquationWithoutSource
 {
 public:
+    HeatEquationWithoutSource(const HeatEquationWithoutSource& other);
     HeatEquationWithoutSource(const Geometry::Mesh2D& mesh, float k, float dt, const FemAssembler::VertexValueFunc& initialValues);
 
+    ~HeatEquationWithoutSource();
+
     const Geometry::Mesh2D& GetGraph() const { return m_mesh; }
-    void SolveNextTimeStep();
+    bool PollNextTimeStepReady();
+    void StartComputation();
 
     const LinearAlgebra::ColumnVector<float>& CurrentSolution() const { return m_currentSolution; }
 
     float CurrentTime() const { return m_time; }
 
 private:
+    std::future<LinearAlgebra::ColumnVector<float>> CreateNextTimeStepComputationTask() const;
+    std::future<LinearAlgebra::ColumnVector<float>> m_computeNextStepTask;
     Geometry::Mesh2D m_mesh;
     float m_k, m_dt;
     float m_time;

--- a/Rendering/src/Render/Core/Renderer.hpp
+++ b/Rendering/src/Render/Core/Renderer.hpp
@@ -9,11 +9,6 @@ namespace Render
 {
     class Renderer
     {
-    private:
-        ShaderProgram m_solidColorShader;
-        ShaderProgram m_vertexColorShader;
-        ShaderProgram m_scalarColorShader;
-
     public:
         Renderer();
         ~Renderer();
@@ -41,9 +36,15 @@ namespace Render
         void DrawElements(const IndexBuffer<T>& elements);
 
         void UpdateCamera(const CameraTransformation& transformation);
+
+    private:
+        ShaderProgram m_solidColorShader;
+        ShaderProgram m_vertexColorShader;
+        ShaderProgram m_scalarColorShader;
     };
 
     template <typename T>
+    // ReSharper disable once CppMemberFunctionMayBeStatic
     void Renderer::Draw(const VertexArrayObject& vao, const IndexBuffer<T>& elements, const ShaderProgram& program)
     {
         program.Use();
@@ -53,14 +54,16 @@ namespace Render
     }
 
     template <typename T>
-    inline void Renderer::DrawLines(const IndexBuffer<T>& elements)
+    // ReSharper disable once CppMemberFunctionMayBeStatic
+    void Renderer::DrawLines(const IndexBuffer<T>& elements)
     {
         elements.Bind();
         GLCHECK(glDrawElements(GL_LINES, elements.GetPrimitiveSize(), GL_UNSIGNED_INT, NULL));
     }
 
     template <typename T>
-    inline void Renderer::DrawElements(const IndexBuffer<T>& elements)
+    // ReSharper disable once CppMemberFunctionMayBeStatic
+    void Renderer::DrawElements(const IndexBuffer<T>& elements)
     {
         elements.Bind();
         GLCHECK(glDrawElements(GL_TRIANGLES, elements.GetPrimitiveSize(), GL_UNSIGNED_INT, NULL));


### PR DESCRIPTION
Both computing and rendering the time dependent head equation with FEM are currently done on the same thread. This computation is done before each render stage, and is therefore blocking the main loop. Large computations should move to background threads to avoid blocking.